### PR TITLE
get it running on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ android/keystores/debug.keystore
 index.android.js
 index.ios.js
 target/
+.re-natal
 
 # Figwheel
 #

--- a/.re-natal
+++ b/.re-natal
@@ -1,7 +1,7 @@
 {
   "name": "HundredPushups",
   "interface": "rum",
-  "androidHost": "localhost",
+  "androidHost": "10.0.2.2",
   "iosHost": "localhost",
   "envRoots": {
     "dev": "env/dev",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To open emacs with access to inf-clojure and a REPL, do
 To get started with your new app, first cd into its directory:
 `cd hundred-pushups`
 
+
+### Running in iOS
 Open iOS app in xcode and run it:
 
 `react-native run-ios`
@@ -38,10 +40,43 @@ Reload the app in simulator
 At the REPL prompt type this:
 `(in-ns 'hundred-pushups.ios.core)`
 
+
+### Running in Android
+
+Open Android project in Android Studio
+
+* Upgrade Android Studio
+* Android Studio, open project `./android`
+* open emulator or connect device
+* Run the app
+  * `react-native run-android`
+  * run app "click play button" (select simulator or device)
+  * either way app will fail until figwheel is running, but you need the initial build to start figwheel
+* run figwheel
+* re-run the app as above this time it should connect to figwheels prompt 
+
+To use figwheel type:
+
+```bash
+re-natal use-android-device avd
+re-natal use-figwheel
+lein figwheel android
+```
+
+If you get an error make sure you have a simulator or real device already running.
+
+Reload the app in simulator
+
+At the REPL prompt type this:
+`(in-ns 'hundred-pushups.android.core)`
+
+### Interacting with Running App
+
 Changes you make via the REPL or by changing your .cljs files should appear live.
 
-Try this command as an example:
-` (dispatch [:set-greeting "Hi everyone"])`
+Try this command as an example: 
+`(dispatch [:set-greeting "Hi everyone"])`
+
 
 ### Tests
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Nov 27 19:19:53 MST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/env/dev/env/android/main.cljs
+++ b/env/dev/env/android/main.cljs
@@ -10,7 +10,7 @@
 (def root-el (r/as-element [reloader]))
 
 (figwheel/watch-and-reload
- :websocket-url "ws://localhost:3449/figwheel-ws"
+ :websocket-url "ws://10.0.2.2:3449/figwheel-ws"
  :heads-up-display false
  :jsload-callback #(swap! cnt inc))
 


### PR DESCRIPTION
updates to the readme and some of the Android init files to get it running... I think we will want to remove `.re-natal` I added to gitignore but then didn't remove the file as it might be good to chat about that a bit, as I see the host is also referenced in a java file...  So perhaps we keep the file and can use ENV vars or something?